### PR TITLE
Fix the Node.js deprecation warning: `DEP0013`

### DIFF
--- a/main.js
+++ b/main.js
@@ -102,7 +102,7 @@ const varidateInputFile = function(input_file, cb){
             return;
         }
         cb();
-        fs.close(fd);
+        fs.closeSync(fd);
     });
 };
 


### PR DESCRIPTION
> DEP0013: fs asynchronous function without callback
> Type: Runtime
> Calling an asynchronous function without a callback is deprecated.

Ref: https://nodejs.org/api/deprecations.html#deprecations_dep0013_fs_asynchronous_function_without_callback